### PR TITLE
Proposal for improved marker placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .cache/
 dist/
 sample.html
+.idea/

--- a/Node.ts
+++ b/Node.ts
@@ -1,3 +1,8 @@
+export interface NodeSize {
+  width: number;
+  height: number;
+}
+
 interface Node {
   title: string;
   id: number;
@@ -7,7 +12,7 @@ interface Node {
   y: number;
   previousX: number;
   previousY: number;
-  size: Array<number>;
+  size: NodeSize;
 }
 
 export default Node;

--- a/Simulation.ts
+++ b/Simulation.ts
@@ -4,6 +4,7 @@ import Feature from "./Feature";
 import Node from "./Node";
 import Map from "./Map";
 import { MapboxGeoJSONFeature } from "mapbox-gl";
+import {getTextSize} from "./utils";
 
 class Simulation {
   nodes: Array<Node>;
@@ -29,7 +30,7 @@ class Simulation {
         y: coordinates.y,
         previousX: coordinates.x,
         previousY: coordinates.y,
-        size: [feature.title.length * 10, 18],
+        size: getTextSize(feature.title),
       };
     });
   }
@@ -41,6 +42,8 @@ class Simulation {
         .forceSimulation()
         // Add a collision detection force to the simulation.
         .force("collision", rectCollide())
+        .force("x", d3.forceX<Node>().x(d => d.lng))
+        .force("y", d3.forceY<Node>().y(d => d.lat))
         .stop()
     );
   }
@@ -61,14 +64,12 @@ class Simulation {
         y: coordinates.y,
         previousX: coordinates.x,
         previousY: coordinates.y,
-        size: [feature.properties.title.length * 10, 18],
+        size: getTextSize(feature.properties.title),
       };
     });
 
     this.sim.nodes(this.nodes);
-    for (var i = 0; i < 120; i++) {
-      this.sim.tick();
-    }
+    this.sim.tick(120);
 
     return this.nodes;
   }

--- a/rectCollide.ts
+++ b/rectCollide.ts
@@ -1,5 +1,6 @@
 import Node from "./Node";
 import { quadtree, QuadtreeLeaf } from "d3";
+import {getOffsets} from "./utils";
 /** Collision detection with quadtree.
  *
  * Will compare node to other nodes, using a quadtree,
@@ -15,49 +16,46 @@ function forceCollide() {
       .x((d) => d.x)
       .y((d) => d.y)
       .addAll(nodes);
+
     for (const node of nodes) {
       const l1 = node.x;
-      const r1 = node.x + node.size[0];
+      const r1 = node.x + node.size.width;
       const t1 = node.y;
-      const b1 = node.y + node.size[1];
+      const b1 = node.y + node.size.height;
 
       /**
        * visit each squares in the quadtree x1 y1 x2 y2
        * constitutes the coordinates of the square want
        * to check if each square is a leaf node (has data prop)
        */
-      q.visit((visited, x1, y1, x2, y2) => {
-        /** Is a leaf node, and is not checking against itself */
-        if (isLeafNode(visited) && visited.data.id !== node.id) {
-          const l2 = visited.data.x;
-          const r2 = visited.data.x + visited.data.size[0];
-          const t2 = visited.data.y;
-          const b2 = visited.data.y + node.size[1];
-
-          /** We have a collision */
-          if (l2 < r1 && l1 < r2 && t1 < b2 && t2 < b1) {
-            /** Calculate intersecting rectangle */
-            const xLeft = Math.max(l1, l2);
-            const yTop = Math.max(t1, t2);
-            const xRight = Math.min(r1, r2);
-            const yBottom = Math.min(b1, b2);
-
-            /** Move the rectangles apart, so that they don't overlap anymore. 🙅🏼 */
-
-            /* Find which direction has biggest overlap */
-            if (xRight - xLeft > yBottom - yTop) {
-              /** Biggest in x direction (move y) */
-              const dy = (yBottom - yTop) / 2;
-              node.y -= dy;
-              visited.data.y += dy;
-            } else {
-              /** Biggest in y direction (move x) */
-              const dx = (xRight - xLeft) / 2;
-              node.x -= dx;
-              visited.data.x += dx;
-            }
-          }
+      q.visit((visitedNode, x1, y1, x2, y2) => {
+        /** Is not a leaf node or is checking against itself */
+        if (!isLeafNode(visitedNode) || visitedNode.data.id === node.id) {
+          return;
         }
+
+        const visited: Node = visitedNode.data;
+        const l2 = visited.x;
+        const r2 = visited.x + visited.size.width;
+        const t2 = visited.y;
+        const b2 = visited.y + node.size.height;
+
+        /** We don't have a collision */
+        if (l2 >= r1 || l1 >= r2 || t1 >= b2 || t2 >= b1) {
+          return;
+        }
+
+        /** Move the rectangles apart, so that they don't overlap anymore. 🙅🏼 */
+        const { dx, dy } = getOffsets(
+            { l: l1, t: t1, r: r1, b: b1 },
+            { l: l2, t: t2, r: r2, b: b2 }
+        );
+        node.x -= dx;
+        visited.x += dx;
+
+        node.y -= dy;
+        visited.y += dy;
+
         return x1 > r1 || x2 < l1 || y1 > b1 || y2 < t1;
       });
     }

--- a/utils.ts
+++ b/utils.ts
@@ -1,3 +1,5 @@
+import Node, {NodeSize} from "./Node";
+
 // b - beginning position
 // e - ending position
 // i - your current value (0-99)
@@ -5,4 +7,65 @@ function getTween(b: number, e: number, i: number) {
   return b + (i / 200) * (e - b);
 }
 
-export { getTween };
+type TNodeBounds = {
+  t: number,
+  r: number,
+  b: number,
+  l: number
+}
+
+function getOffsets(node1: TNodeBounds, node2: TNodeBounds): { dx: number, dy: number } {
+  /** Calculate intersecting rectangle */
+  const xLeft = Math.max(node1.l, node2.l);
+  const yTop = Math.max(node1.t, node2.t);
+  const xRight = Math.min(node1.r, node2.r);
+  const yBottom = Math.min(node1.b, node2.b);
+  const xCenter = (xLeft + xRight) / 2;
+  const yCenter = (yTop + yBottom) / 2;
+
+  let dx = 0, dy = 0;
+  if((node1.l <= node2.l && node1.r >= node2.r)
+      || (node2.l <= node1.l && node2.r >= node1.r)) {
+    // The larger node completely spans the smaller node, don't move sideways, since it won't matter
+  } else if(node1.l <= node2.l) {
+    // Node 1 is left of node 2
+    dx = xCenter - xLeft;
+  } else {
+    // Node 1 is right of node 2
+    dx = -(xCenter - xLeft);
+  }
+
+  if((node1.t <= node2.t && node1.b >= node2.b)
+      || (node2.t <= node1.t && node2.b >= node1.b)) {
+    // The taller node completely spans the smaller node, don't move up/down, since it won't matter
+  } else if(node1.t <= node2.t) {
+    // Node 1 is above node 2
+    dy = yCenter - yTop;
+  } else {
+    // Node 1 is below node 2
+    dy = -(yCenter - yTop);
+  }
+  return { dx, dy };
+}
+
+/**
+ * Measure the width of a text were it to be rendered using a given font.
+ *
+ * @param {string} text the text to be measured
+ * @param {string} font a valid css font value
+ *
+ * @returns {number} the width of the rendered text in pixels.
+ */
+function getTextSize(text: string, font = "14px \"Open Sans Semibold\""): NodeSize {
+  const element = document.createElement("canvas");
+  const context = element.getContext("2d") as CanvasRenderingContext2D;
+  context.font = font;
+
+  const textSize = context.measureText(text);
+  return {
+    width: textSize.width,
+    height: textSize.actualBoundingBoxAscent + textSize.actualBoundingBoxDescent,
+  };
+}
+
+export { getTween, getOffsets, getTextSize };


### PR DESCRIPTION
As per https://stackoverflow.com/a/64477146/5015356

I've ended up making several changes to your code, which I think should improve this behaviour.

 1. (In preparation) I've changed the `Node.size` property from an array to an object;
 2. Your boxes for the labels were way too big, so they ended up triggering collisions where there were none. I've replaced it with [a more fine-grained method](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText) of finding the text width on a canvas;
 3. In order to pull the nodes towards their original positions, I've added `forceX` and `forceY` to the simulation;
4. If you only move in the direction of the biggest overlap, then you can eventually get into the positions where nodes are pushing each other vertically, while there is a lot of space horizontally. To reduce the chances of this happening, I propose moving in both directions, by taking the intersecting rectangle you've computed, and moving both nodes by it's `width / 2` and `height / 2` such that only their corners should touch. This will give the `x` and `y` forces more freedom to then pull the nodes then further back to their anchors.